### PR TITLE
Upgrade ember-cli-babel to 6.14.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,8 +24,8 @@
     "test": "ember try:each"
   },
   "dependencies": {
-    "ember-cli-babel": "^5.1.7",
-    "ember-cli-htmlbars": "^1.1.1"
+    "ember-cli-babel": "^6.14.1",
+    "ember-cli-htmlbars": "^2.0.3"
   },
   "devDependencies": {
     "broccoli-asset-rev": "^2.4.5",


### PR DESCRIPTION
ember-cli-babel version 5.x.x is deprecated